### PR TITLE
automatic tests worflow (#3)

### DIFF
--- a/.github/workflows/fasttest.yml
+++ b/.github/workflows/fasttest.yml
@@ -1,0 +1,26 @@
+name: Fast Test Suite
+
+on: [push, pull_request]
+
+jobs:
+  phpunit:
+    name: PHP ${{ matrix.php }} / No Composer
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+
+    steps:
+      - name: Checkout Project
+        uses: actions/checkout@v2
+
+      - name: Install PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring
+          ini-values: date.timezone='UTC', session.save_path="${{ runner.temp }}"
+
+      - name: PHP Unit tests for PHP ${{ matrix.php }}
+        run: php ./tests/WithoutComposerTest.php

--- a/.github/workflows/fulltest.yml
+++ b/.github/workflows/fulltest.yml
@@ -1,0 +1,56 @@
+name: Full Test Suite
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+env:
+  DEFAULT_COMPOSER_FLAGS: "--prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi"
+  PHPUNIT_COVERAGE_FLAGS: "--coverage-clover=clover.xml"
+  PHPUNIT_EXCLUDE_GROUP: "--exclude-group mssql,oci,wincache,xcache,zenddata,cubrid"
+  XDEBUG_MODE: coverage, develop
+
+jobs:
+  phpunit:
+    name: PHP ${{ matrix.php }} / PHPUnit / Coverage / Composer
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['7.3']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: pecl
+          extensions: mbstring
+          ini-values: date.timezone='UTC', session.save_path="${{ runner.temp }}"
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer update ${{ env.DEFAULT_COMPOSER_FLAGS }}
+
+      - name: PHP Unit tests for PHP ${{ matrix.php }}
+        run: vendor/bin/phpunit --verbose ${{ env.PHPUNIT_COVERAGE_FLAGS }} ${{ env.PHPUNIT_EXCLUDE_GROUP }} --colors=always
+        
+      - name: Report Coverage to Codacy
+        run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report --project-token ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 composer.lock
 composer.phar
+ocular.phar
 /vendor/
+/.phpunit.cache/

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,3 @@
-
 {
     "name": "rodrigodornelles/php-array-lib",
     "description": "simple libary for functional programing paradigm with arrays",
@@ -16,7 +15,10 @@
         "source": "http://github.com/rodrigodornelles/php-array-lib"
     },
     "require": {
-        "php": "^7.4"
+        "php": "^5.4|^5.5|^5.6|^7.0|^7.1|^7.2|^7.3|^7.4|^8.0|^8.1|^8.2"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheResultFile=".phpunit.cache/test-results"
+         executionOrder="depends,defects"
+         forceCoversAnnotation="true"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         convertDeprecationsToExceptions="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage cacheDirectory=".phpunit.cache/code-coverage"
+              processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
+</phpunit>

--- a/src/ArrayCreate.php
+++ b/src/ArrayCreate.php
@@ -59,7 +59,7 @@ class ArrayCreate
      */
     public function first()
     {
-        $item = $this->_array[array_key_first($this->_array)];
+        $item = current(array_slice($this->_array, 0, 1));
         return is_array($item)? self::from($item): $item;
     }
 
@@ -97,7 +97,8 @@ class ArrayCreate
      */
     public function last()
     {
-        $item = $this->_array[array_key_last($this->_array)];
+        $item = end($this->_array);
+        reset($this->_array);
         return is_array($item)? self::from($item): $item;
     }
 

--- a/tests/ArrayCreateTest.php
+++ b/tests/ArrayCreateTest.php
@@ -1,0 +1,80 @@
+<?php 
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \ArrayCreate
+ */
+class ArrayCreateTest extends TestCase
+{
+
+    public function testConstructorFrom()
+    {
+        $array = ArrayCreate::from([]);
+        $this->assertInstanceOf(ArrayCreate::class, $array);
+    }
+
+    public function testFilter()
+    {
+        $expected = [1, 3, 5, 7, 9];
+        $expected = array_combine($expected, $expected);
+        $actual = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        $actual = ArrayCreate::from($actual)
+            ->filter(function($n){return $n % 2;})
+            ->construct();
+        
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testFirst()
+    {
+        $expected = 'first';
+        $actual = ['first', 'last'];
+        $actual = ArrayCreate::from($actual)
+            ->first();
+        
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testFlip()
+    {
+        $expected = ['bar' => 'foo'];
+        $actual = ['foo' => 'bar'];
+        $actual = ArrayCreate::from($actual)
+            ->flip()
+            ->construct();
+        
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testJoin()
+    {
+        $expected = 'foo, bar, z';
+        $actual = ['foo', 'bar', 'z'];
+        $actual = ArrayCreate::from($actual)
+            ->join(', ');
+
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testLast()
+    {
+        $expected = 'last';
+        $actual = ['first', 'last'];
+        $actual = ArrayCreate::from($actual)
+            ->last();
+        
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testMap()
+    {
+        $expected = [2, 4, 6, 8];
+        $actual = [1, 2, 3, 4];
+        $actual = ArrayCreate::from($actual)
+            ->map(function($n){return $n * 2;})
+            ->construct();
+        
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/tests/WithoutComposerTest.php
+++ b/tests/WithoutComposerTest.php
@@ -1,7 +1,7 @@
 <?php 
 
 assert_options(ASSERT_BAIL, true);
-require __DIR__.'/../vendor/autoload.php';
+require_once __DIR__.'/../src/ArrayCreate.php';
 
 /** 
  * test 1
@@ -12,12 +12,12 @@ assert(ArrayCreate::from($array)->join(',') == 'FOO,BAR,Z');
 /** test 2 */
 $string = "0,1,2,3,5";
 $array = explode(",", $string);
-$array = ArrayCreate::from($array)->map(fn($n) => (int) $n)->construct();
+$array = ArrayCreate::from($array)->map(function($n) {return (int) $n;})->construct();
 assert(array_filter($array, 'is_int'));
 
 /** test 3 */
 $array = [1, 2, 3, 4, 5, 6, 7, 8, 9 ,10];
-$array = ArrayCreate::from($array)->filter(fn($n) => $n % 2)->construct();
+$array = ArrayCreate::from($array)->filter(function($n) {return $n % 2;})->construct();
 assert(count($array) == 5);
 
 /** test 4 */
@@ -32,4 +32,4 @@ $array = ArrayCreate::from($array)->flip()->construct();
 assert($array['first'] == 0);
 assert($array['last'] == 2);
 
-print("done.\n");
+print("OK.\n");


### PR DESCRIPTION
* change basic tests to without composer tests

* add PHPUnit Test Framework

* add ocular.phar to .gitignore

* change arrow function to anonymous function to php <7.3 support

* removed autoload dependency (composer) (psr4)

* methods first|last compatible with php < 7.0

* add full test suite workflow

* add fast test suite workflow

* add all compatible bersions of php on composer